### PR TITLE
Implemented basic sign up functionality

### DIFF
--- a/src/components/Sign Up/index.js
+++ b/src/components/Sign Up/index.js
@@ -7,11 +7,68 @@ export default class Signup extends Component {
     password: '',
     password_confirmation: ''
   }
+  signUserUp = (event) => {
+    event.preventDefault();
+    fetch('http://localhost:3000/registration', {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json"
+      },
+      body: JSON.stringify({
+        email: this.state.email,
+        password: this.state.password,
+        password_confirmation: this.state.password_confirmation
+      })
+    })
+    .then(
+      this.setState({
+        email: '',
+        password: '',
+        password_confirmation: ''
+      })
+    )
+    // .then(
+    //   this.props.loadLoginPage(event)
+    // )
+  }
+
+  updateEmail = (event) => {
+    this.setState({
+      email: event.target.value
+    })  
+  }
+
+  updatePassword = (event) => {
+    this.setState({
+      password: event.target.value
+    })
+  }
+
+  updatePasswordconfirmation = (event) => {
+    this.setState({
+      password_confirmation: event.target.value
+    })
+  }
 
   render() {
     return(
       <section className='signup-zone'>
-        <h1>Sign up!</h1>
+        <form id="form-submissions" onSubmit={event => this.signUserUp(event)}>
+          <label htmlFor="signup-email">Email</label>
+          <input id="signup-email" type="text" placeholder="example@example.com"name="email"
+          onChange={event => this.updateEmail(event)} value={this.state.email}/>
+
+          <label htmlFor="signup-password">Password</label>
+          <input id="signup-password" type="password" placeholder="password" name="password"
+          onChange={event => this.updatePassword(event)} value={this.state.password}/>
+
+          <label htmlFor="signup-password_confirmation">Password Confirmation</label>
+          <input id="signup-password_confirmation" type="password" placeholder="password_confirmation" name="password_confirmation"
+          onChange={event => this.updatePasswordconfirmation(event)} value={this.state.password_confirmation}/>
+          
+          <input type="submit" value="Sign up"/>
+        </form>
       </section>
     )
   }

--- a/src/components/Sign Up/main.css
+++ b/src/components/Sign Up/main.css
@@ -1,7 +1,6 @@
 .signup-zone {
   display: flex;
-  justify-content: center;
   align-items: center;
-  min-height: 20vh;
-  font-size: 5rem;
+  justify-content: center;
+  height: 50vh;
 }


### PR DESCRIPTION
- Updated the Signup component to render a form and manage state for
email, password, and password confirmation and then, upon submission,
send a fetch request to the registration controller to create a new
user account.
- Currently only works on local host with the back end
up and running.