### PR TITLE
Starts process of linking with api hosted on Heroku

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -26,7 +26,7 @@ export default class App extends Component {
   }
 
   componentDidMount = () => {
-    fetch('http://localhost:3000/standard_cards')
+    fetch('https://safe-bayou-71328.herokuapp.com/standard_cards')
       .then(response => response.json())
       .then(cards => this.setState({
           allCards: cards
@@ -93,7 +93,7 @@ export default class App extends Component {
         })
       })
     :
-      fetch('http://localhost:3000/decks', {
+      fetch('https://safe-bayou-71328.herokuapp.com/decks', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
Currently, authentication and deck fetching with user id doesn't
work on the api when hosted on Heroku. However, standard cards
have been seeded and are functioning properly.

This commit adds in the fetch request to the Heroku api.