### PR TITLE
Modifies Card component CSS for 375px and lower resolutions

### DIFF
--- a/src/components/Card/main.css
+++ b/src/components/Card/main.css
@@ -10,3 +10,11 @@
   height: 4vw;
   padding: 1rem;
 }
+
+@media screen and (max-width: 375px) {
+
+  .card img {
+    border-radius: 5px;
+    width: 65px;
+  }
+}


### PR DESCRIPTION
Applies a temporary fix to the card sizes on screens of 375px or lower
resolution.

The cards vary in size when using em as a unit, as opposed
to px, for the card width. I need to find a future alternative to this.