### PR TITLE
Adds media queries for 1366px resolutions

### DIFF
--- a/src/components/Card/main.css
+++ b/src/components/Card/main.css
@@ -18,3 +18,11 @@
     width: 65px;
   }
 }
+
+@media screen and (max-width: 1366px) {
+
+  .card img {
+    border-radius: 10px;
+    width: 137px;
+  }  
+}

--- a/src/components/Home/main.css
+++ b/src/components/Home/main.css
@@ -26,3 +26,16 @@ p {
     text-align: center;
   }
 }
+
+@media screen and (max-width: 1366px) {
+
+  .home-container img{
+    width: 29em;
+    padding-top: 2em;
+  }
+  
+  p {
+    font-size: 4rem;
+    text-align: center;
+  }  
+}


### PR DESCRIPTION
The Home component image size and text size have been altered to be
more suitable for that range of resolution.

Also changes the card size for Card and Deck Builder pages to increase
the size of the gap between the cards. Previously they were a bit
smooshed together.