### PR TITLE
Changes the amount of cards displayed per page

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -125,7 +125,7 @@ export default class App extends Component {
               <Route exact path="/">
                 <Home user={user}/>
               </Route>
-              <Route path="/cards" render={(...props) => <CardContainer allCards={allCards} method={this.viewCard}/>} />
+              <Route path="/cards" render={(...props) => <CardContainer allCards={allCards} method={this.viewCard} cardPageCount={27}/>} />
               <Route path='/deckbuilder'>
                 <DeckBuilder 
                   allCards={allCards} 

--- a/src/components/CardContainer/index.js
+++ b/src/components/CardContainer/index.js
@@ -5,7 +5,7 @@ import './main.css'
 export default class CardContainer extends Component {
   state = {
     currentPage: 1,
-    cardsPerPage: 9
+    cardsPerPage: this.props.cardPageCount
   }
 
   decrementButton = () => {

--- a/src/components/DeckBuilder/index.js
+++ b/src/components/DeckBuilder/index.js
@@ -10,6 +10,7 @@ export default ({allCards, selectedCards, user, addCard, removeCard, saveNewDeck
       <CardContainer 
         allCards={allCards}
         method={addCard}
+        cardPageCount={9}
       />
       <CardContainer 
         allCards={selectedCards}


### PR DESCRIPTION
The CardContainer component now expects a prop called cardPageCount
that tells it how many cards to render per page. The DeckBuilder page
still only renders 9 cards at a time but the Card page now renders 27.

In the future, I would like to conditionally change the amount per page
based on the size of the screen. That way mobile compatability is more
reasonable. Either that or I will apply an overflow scroll to it at
certain resolutions.