### PR TITLE
Fix home component text and image size

### DIFF
--- a/src/components/Home/main.css
+++ b/src/components/Home/main.css
@@ -27,7 +27,7 @@ p {
   }
 }
 
-@media screen and (max-width: 1366px) {
+@media screen and (min-width: 376px) and (max-width: 1366px) {
 
   .home-container img{
     width: 29em;


### PR DESCRIPTION
After adding in other resolution media queries, the previous 375px
media queries did not work. This is because I did not specify a minimum
resolution size for the higher resolution media queries. I have now
specified min-width resolution sizes for the media queries bigger than
375px.