### PR TITLE
Adds IDs to the deckbuilder links in Navigation. Omits editDeck method

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -54,10 +54,10 @@ const App = () => {
     console.log('to be added!', card);
   };
 
-  const editDeck = deck => {
-    setSelectedCards(deck.attributes.standard_cards);
-    setDeckId(deck.attributes.id);
-  };
+  // const editDeck = deck => {
+  //   setSelectedCards(deck.attributes.standard_cards);
+  //   setDeckId(deck.attributes.id);
+  // };
 
   const resetDeck = () => {
     setDeckId(null);
@@ -85,7 +85,7 @@ const App = () => {
               <Login loginUser={loginUser} logoutUser={logoutUser} user={user}/>
             </Route>
             <Route path='/profile'>
-              <Profile user={user} decks={decks}/>
+              <Profile user={user} decks={decks} />
             </Route>
           </Switch>
         </Router>

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -25,7 +25,7 @@ const Navigation = ({loggedIn, reset, mobile}) => {
                 <Link to="/cards">Cards</Link>
               </li>
               <li>
-                <Link to="/deckbuilder">Deck Builder</Link>
+                <Link to="/deckbuilder" id='deckbuilder'>Deck Builder</Link>
               </li>
               <li onClick={reset}>
                 <Link to="/profile">Profile</Link>
@@ -53,7 +53,7 @@ const Navigation = ({loggedIn, reset, mobile}) => {
                 <Link to="/cards">Cards</Link>
               </li>
               <li>
-                <Link to="/deckbuilder">Deck Builder</Link>
+                <Link to="/deckbuilder" id='deckbuilder'>Deck Builder</Link>
               </li>
               <li>
                 <Link to="/signup">Sign Up</Link>


### PR DESCRIPTION
I added an ID of 'deckbuilder' to the two links in the Navigation
component for a future feature I will be implementing through the
Profile component.

Additionally, since editDeck is currently broken as it is written, I
have commented it out and removed it from the Profile component props.