### PR TITLE
Moves more specific Deckbuilder and Profile logic to their components

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -19,7 +19,7 @@ const App = () => {
 
   const [ allCards, setAllCards ]           = useState([]);
   const [ user, setUser ]                   = useState(null);
-  const [ decks, setDecks ]                 = useState({});
+  const [ decks, setDecks ]                 = useState(null);
   const [ deck_id, setDeckId ]              = useState(null);
   const [ isMobile, setIsMobile ]           = useState(false);
 
@@ -42,7 +42,7 @@ const App = () => {
       ? null
       : localStorage.getItem('authToken') === 'undefined'
         ? null
-        : setUser(token.user) && setDecks(token.decks)
+        : (setUser(token.user), setDecks(token.decks))
     );
   };
 
@@ -51,13 +51,8 @@ const App = () => {
   };
 
   const viewCard = card => {
-    console.log('to be added!', card);
+    console.log(deck_id);
   };
-
-  // const editDeck = deck => {
-  //   setSelectedCards(deck.attributes.standard_cards);
-  //   setDeckId(deck.attributes.id);
-  // };
 
   const resetDeck = () => {
     setDeckId(null);
@@ -85,7 +80,7 @@ const App = () => {
               <Login loginUser={loginUser} logoutUser={logoutUser} user={user}/>
             </Route>
             <Route path='/profile'>
-              <Profile user={user} decks={decks} />
+              <Profile user={user} decks={decks} setDeckId={setDeckId}/>
             </Route>
           </Switch>
         </Router>

--- a/src/components/CardContainer/index.js
+++ b/src/components/CardContainer/index.js
@@ -21,7 +21,7 @@ export default class CardContainer extends Component {
   }
 
   render() {
-    const { currentPage, cardsPerPage } = this.state;
+    const { currentPage, cardsPerPage = this.props.allCards.length } = this.state;
     const allCards = this.props.allCards
 
     const indexOfLastCard = currentPage * cardsPerPage;

--- a/src/components/DeckBuilder/index.js
+++ b/src/components/DeckBuilder/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './main.css'
 
 import CardContainer from '../CardContainer';
@@ -7,6 +7,13 @@ export default ({allCards, user, deck_id}) => {
 
   const [ selectedCards, setSelectedCards ] = useState([]);
 
+  useEffect(() => {
+    if (deck_id) {
+      fetch(`https://safe-bayou-71328.herokuapp.com/decks/${deck_id}`)
+        .then(response => response.json())
+        .then(deck => setSelectedCards(deck.standard_cards))
+    }
+  }, [deck_id])
   const addCard = card => {
     console.log(selectedCards);
     return (
@@ -27,7 +34,7 @@ export default ({allCards, user, deck_id}) => {
   const saveDeck = () => {
     deck_id !== null
     ? 
-      fetch(`http://localhost:3000/decks/${deck_id}`, {
+      fetch(`https://safe-bayou-71328.herokuapp.com/decks/${deck_id}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json'

--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -15,7 +15,7 @@ export default class Login extends Component {
 
   logUserIn = (event) => {
     event.preventDefault();
-    fetch('http://localhost:3000/authenticate', {
+    fetch('https://safe-bayou-71328.herokuapp.com/authenticate', {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -21,7 +21,7 @@ const Navigation = ({loggedIn, reset, mobile}) => {
               <li onClick={reset}>
                 <Link to="/">Home</Link>
               </li>
-              <li onClick={reset}>
+              <li>
                 <Link to="/cards">Cards</Link>
               </li>
               <li>

--- a/src/components/Profile/index.js
+++ b/src/components/Profile/index.js
@@ -2,15 +2,23 @@ import React from 'react';
 import './main.css'
 import CardContainer from '../CardContainer';
 
-export default ({ user, decks, method }) => (
-  
-  ( user !== null
+const Profile = ({ user, decks, setDeckId}) => {
+
+  const editDeck = deck => {
+    setDeckId(deck.attributes.id);
+    document.getElementById('deckbuilder').click();
+  };
+
+  return ( 
+    user !== null
     ?
     <section className='profile'>
       <h1>Email: {user.data.attributes.email}</h1>
-      { user !== null ? <CardContainer allCards={decks.data} method={method} edit='edit'/> : null }
+      <CardContainer allCards={decks.data} method={editDeck} edit='edit'/>
     </section>
     :
     null
   )
-)
+};
+
+export default Profile;

--- a/src/components/Sign Up/index.js
+++ b/src/components/Sign Up/index.js
@@ -9,7 +9,7 @@ export default class Signup extends Component {
   }
   signUserUp = (event) => {
     event.preventDefault();
-    fetch('http://localhost:3000/registration', {
+    fetch('https://safe-bayou-71328.herokuapp.com/registration', {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
My main App component contained a lot of logic that could be stored in
the child components. As such, I moved the addCard, removeCard, and
saveDeck logic, as well as the selectedCards state, to my Deckbuilder
component.

Additionally, I moved the editDeck method inside of my Profile component
and changed how it works. Now, it changes the DeckId and redirects the
user to the Deckbuilder component.

Upon changing the deck_id state, the Deckbuilder component now fires off
a fetch request to get the specific deck's cards for populating the
selectedCards state.

Also, I have changed the fetch request URLs in my Sign Up and Login
components to properly hit my live API instead of the localhost.