### PR TITLE
Updates SignUp and Login components to use hooks

### DIFF
--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -1,19 +1,19 @@
-import React, { Component } from 'react';
-import './main.css'
+import React, { useState, useEffect } from 'react';
+import './main.css';
 
-export default class Login extends Component {
+const Login = ({loginUser, logoutUser, user}) => {
 
-  state = {
-    email: '',
-    password: ''
-  }
+  const [ email, updateEmail ]       = useState('');
+  const [ password, updatePassword ] = useState('');
 
-  componentDidMount = () =>{
+  useEffect(() => {
     localStorage.removeItem('authToken')
-    return this.props.user !== null ? this.props.logoutUser() : null
-  }
+    if(user !== null) {
+      logoutUser();
+    };
+  }, []);
 
-  logUserIn = (event) => {
+  const logUserIn = (event) => {
     event.preventDefault();
     fetch('https://safe-bayou-71328.herokuapp.com/authenticate', {
       method: "POST",
@@ -22,50 +22,36 @@ export default class Login extends Component {
         "Accept": "application/json"
       },
       body: JSON.stringify({
-        email: this.state.email,
-        password: this.state.password
+        email: email,
+        password: password
       })
     })
     .then(response => response.json())
     .then(token => {
-      localStorage.setItem('authToken', token.auth_token)
-      this.props.loginUser(token)
+      localStorage.setItem('authToken', token.auth_token);
+      loginUser(token);
     })
     .then(
-      this.setState({
-        email: '',
-        password: ''
-      })
-    )
-  }
+      updateEmail(''),
+      updatePassword('')
+    );
+  };
 
-  updateEmail = (event) => {
-    this.setState({
-      email: event.target.value
-    })  
-  }
+  return(
+    <section className='login-zone'>
+      <form id='login-form-submissions' onSubmit={event => logUserIn(event)}>
+        <label htmlFor="login-email">Email</label>
+        <input id="login-email" type="text" placeholder="example@example.com" name="email" 
+        onChange={event => updateEmail(event.target.value)} value={email} />
 
-  updatePassword = (event) => {
-    this.setState({
-      password: event.target.value
-    })
-  }
+        <label htmlFor="login-password">Password</label>
+        <input id="login-password" type="password" placeholder="password" name="password" 
+        onChange={event => updatePassword(event.target.value)} value={password} />
 
-  render() {
-    return(
-      <section className='login-zone'>
-        <form id='login-form-submissions' onSubmit={event => this.logUserIn(event)}>
-          <label htmlFor="login-email">Email</label>
-          <input id="login-email" type="text" placeholder="example@example.com" name="email" 
-          onChange={event => this.updateEmail(event)} value={this.state.email} />
+        <input className='submitButton' type="submit" value="Login" />
+      </form>
+    </section>
+  )
+};
 
-          <label htmlFor="login-password">Password</label>
-          <input id="login-password" type="password" placeholder="password" name="password" 
-          onChange={event => this.updatePassword(event)} value={this.state.password} />
-
-          <input className='submitButton' type="submit" value="Login" />
-        </form>
-      </section>
-    )
-  }
-}
+export default Login;

--- a/src/components/Sign Up/index.js
+++ b/src/components/Sign Up/index.js
@@ -1,13 +1,13 @@
-import React, { Component } from 'react';
-import './main.css'
+import React, { useState } from 'react';
+import './main.css';
 
-export default class Signup extends Component {
-  state = {
-    email: '',
-    password: '',
-    password_confirmation: ''
-  }
-  signUserUp = (event) => {
+const SignUp = () => {
+
+  const [ email, updateEmail ]                                = useState('');
+  const [ password, updatePassword ]                          = useState('');
+  const [ password_confirmation, updatePasswordConfirmation ] = useState('');
+
+  const signUserUp = (event) => {
     event.preventDefault();
     fetch('https://safe-bayou-71328.herokuapp.com/registration', {
       method: "POST",
@@ -16,60 +16,37 @@ export default class Signup extends Component {
         "Accept": "application/json"
       },
       body: JSON.stringify({
-        email: this.state.email,
-        password: this.state.password,
-        password_confirmation: this.state.password_confirmation
+        email: email,
+        password: password,
+        password_confirmation: password_confirmation
       })
     })
     .then(
-      this.setState({
-        email: '',
-        password: '',
-        password_confirmation: ''
-      })
-    )
-    // .then(
-    //   this.props.loadLoginPage(event)
-    // )
-  }
+      updateEmail(''),
+      updatePassword(''),
+      updatePasswordConfirmation('')
+    );
+  };
 
-  updateEmail = (event) => {
-    this.setState({
-      email: event.target.value
-    })  
-  }
+  return(
+    <section className='signup-zone'>
+      <form id="signup-form-submissions" onSubmit={event => signUserUp(event)}>
+        <label htmlFor="signup-email">Email</label>
+        <input id="signup-email" type="text" placeholder="example@example.com"name="email"
+        onChange={event => updateEmail(event.target.value)} value={email}/>
 
-  updatePassword = (event) => {
-    this.setState({
-      password: event.target.value
-    })
-  }
+        <label htmlFor="signup-password">Password</label>
+        <input id="signup-password" type="password" placeholder="password" name="password"
+        onChange={event => updatePassword(event.target.value)} value={password}/>
 
-  updatePasswordconfirmation = (event) => {
-    this.setState({
-      password_confirmation: event.target.value
-    })
-  }
+        <label htmlFor="signup-password_confirmation">Password Confirmation</label>
+        <input id="signup-password_confirmation" type="password" placeholder="password_confirmation" name="password_confirmation"
+        onChange={event => updatePasswordConfirmation(event.target.value)} value={password_confirmation}/>
+        
+        <input className='submitButton'type="submit" value="Sign up"/>
+      </form>
+    </section>
+  );
+};
 
-  render() {
-    return(
-      <section className='signup-zone'>
-        <form id="signup-form-submissions" onSubmit={event => this.signUserUp(event)}>
-          <label htmlFor="signup-email">Email</label>
-          <input id="signup-email" type="text" placeholder="example@example.com"name="email"
-          onChange={event => this.updateEmail(event)} value={this.state.email}/>
-
-          <label htmlFor="signup-password">Password</label>
-          <input id="signup-password" type="password" placeholder="password" name="password"
-          onChange={event => this.updatePassword(event)} value={this.state.password}/>
-
-          <label htmlFor="signup-password_confirmation">Password Confirmation</label>
-          <input id="signup-password_confirmation" type="password" placeholder="password_confirmation" name="password_confirmation"
-          onChange={event => this.updatePasswordconfirmation(event)} value={this.state.password_confirmation}/>
-          
-          <input className='submitButton'type="submit" value="Sign up"/>
-        </form>
-      </section>
-    )
-  }
-}
+export default SignUp;


### PR DESCRIPTION
Since I have been refactoring this application to use hooks instead of
class components, I finally changed over the SignUp and Login forms
to use them.

SignUp only requires use of the useState hook and Login uses both the
useState and useEffect hooks. The useEffect hook is used to remove the
user's auth token when the login component mounts.